### PR TITLE
arch, vmm: Move "generate_common_cpuid" from "CpuManager" to "arch"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "vm-fdt",
  "vm-memory",
  "vm-migration",
+ "vmm-sys-util",
 ]
 
 [[package]]

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -23,6 +23,7 @@ versionize = "0.1.6"
 versionize_derive = "0.1.4"
 vm-memory = { version = "0.5.0", features = ["backend-mmap", "backend-bitmap"] }
 vm-migration = { path = "../vm-migration" }
+vmm-sys-util = { version = ">=0.5.0", features = ["with-serde"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 fdt_parser = { version = "0.1.3", package = 'fdt'}

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -85,7 +85,7 @@ pub mod x86_64;
 pub use x86_64::{
     arch_memory_regions, configure_system, configure_vcpu, generate_common_cpuid,
     get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
-    layout::CMDLINE_START, regs, EntryPoint,
+    layout::CMDLINE_START, regs, CpuidFeatureEntry, EntryPoint,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.

--- a/arch/src/lib.rs
+++ b/arch/src/lib.rs
@@ -83,9 +83,9 @@ pub mod x86_64;
 
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::{
-    arch_memory_regions, configure_system, configure_vcpu, get_host_cpu_phys_bits,
-    initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE, layout::CMDLINE_START, regs, CpuidPatch,
-    CpuidReg, EntryPoint,
+    arch_memory_regions, configure_system, configure_vcpu, generate_common_cpuid,
+    get_host_cpu_phys_bits, initramfs_load_addr, layout, layout::CMDLINE_MAX_SIZE,
+    layout::CMDLINE_START, regs, EntryPoint,
 };
 
 /// Safe wrapper for `sysconf(_SC_PAGESIZE)`.

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -185,6 +185,9 @@ pub enum Error {
 
     /// Error populating CPUID with CPU identification
     CpuidIdentification(vmm_sys_util::fam::Error),
+
+    /// Error checking CPUID compatibility
+    CpuidCheckCompatibility,
 }
 
 impl From<Error> for super::Error {
@@ -194,7 +197,7 @@ impl From<Error> for super::Error {
 }
 
 #[allow(dead_code, clippy::upper_case_acronyms)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum CpuidReg {
     EAX,
     EBX,
@@ -335,6 +338,144 @@ impl CpuidPatch {
         }
 
         false
+    }
+}
+
+pub struct CpuidFeatureEntry {
+    pub function: u32,
+    pub index: u32,
+    pub feature_reg: CpuidReg,
+}
+
+impl CpuidFeatureEntry {
+    fn predefined_feature_entry_list() -> Vec<CpuidFeatureEntry> {
+        vec![
+            // Leaf 0x1, ECX/EDX, feature bits
+            CpuidFeatureEntry {
+                function: 1,
+                index: 0,
+                feature_reg: CpuidReg::ECX,
+            },
+            CpuidFeatureEntry {
+                function: 1,
+                index: 0,
+                feature_reg: CpuidReg::EDX,
+            },
+            // Leaf 0x7, EBX/ECX/EDX, extended features
+            CpuidFeatureEntry {
+                function: 7,
+                index: 0,
+                feature_reg: CpuidReg::EBX,
+            },
+            CpuidFeatureEntry {
+                function: 7,
+                index: 0,
+                feature_reg: CpuidReg::ECX,
+            },
+            CpuidFeatureEntry {
+                function: 7,
+                index: 0,
+                feature_reg: CpuidReg::EDX,
+            },
+            // Leaf 0x7 subleaf 0x1, EBX/ECX/EDX, extended features
+            CpuidFeatureEntry {
+                function: 7,
+                index: 1,
+                feature_reg: CpuidReg::EBX,
+            },
+            CpuidFeatureEntry {
+                function: 7,
+                index: 1,
+                feature_reg: CpuidReg::ECX,
+            },
+            CpuidFeatureEntry {
+                function: 7,
+                index: 1,
+                feature_reg: CpuidReg::EDX,
+            },
+            // Leaf 0x8000_0001, ECX/EDX, CPUID features bits
+            CpuidFeatureEntry {
+                function: 0x8000_0001,
+                index: 0,
+                feature_reg: CpuidReg::ECX,
+            },
+            CpuidFeatureEntry {
+                function: 0x8000_0001,
+                index: 0,
+                feature_reg: CpuidReg::EDX,
+            },
+        ]
+    }
+
+    fn get_features_from_cpuid(
+        cpuid: &CpuId,
+        feature_entry_list: &[CpuidFeatureEntry],
+    ) -> Vec<u32> {
+        let mut features = vec![0; feature_entry_list.len()];
+        for (i, feature_entry) in feature_entry_list.iter().enumerate() {
+            for cpuid_entry in cpuid.as_slice().iter() {
+                if cpuid_entry.function == feature_entry.function
+                    && cpuid_entry.index == feature_entry.index
+                {
+                    match feature_entry.feature_reg {
+                        CpuidReg::EAX => {
+                            features[i] = cpuid_entry.eax;
+                        }
+                        CpuidReg::EBX => {
+                            features[i] = cpuid_entry.ebx;
+                        }
+                        CpuidReg::ECX => {
+                            features[i] = cpuid_entry.ecx;
+                        }
+                        CpuidReg::EDX => {
+                            features[i] = cpuid_entry.edx;
+                        }
+                    }
+                }
+            }
+        }
+
+        features
+    }
+
+    // The function returns `Error` (a.k.a. "incompatible"), when the CPUID features from `src_vm_cpuid`
+    // is not a subset of those of the `dest_vm_cpuid`.
+    pub fn check_cpuid_compatibility(
+        src_vm_cpuid: &CpuId,
+        dest_vm_cpuid: &CpuId,
+    ) -> Result<(), Error> {
+        let feature_entry_list = &Self::predefined_feature_entry_list();
+        let src_vm_features =
+            CpuidFeatureEntry::get_features_from_cpuid(src_vm_cpuid, feature_entry_list);
+        let dest_vm_features =
+            CpuidFeatureEntry::get_features_from_cpuid(dest_vm_cpuid, feature_entry_list);
+
+        // Loop on feature bit and check if the 'source vm' feature is a subset
+        // of those of the 'destination vm' feature
+        let mut compatible = true;
+        for (i, feature_entry) in feature_entry_list.iter().enumerate() {
+            let src_vm_feature = src_vm_features[i];
+            let dest_vm_feature = dest_vm_features[i];
+            let different_feature_bits = src_vm_feature ^ dest_vm_feature;
+            let src_vm_feature_bits_only = different_feature_bits & src_vm_feature;
+            if src_vm_feature_bits_only != 0 {
+                warn!(
+                    "Detected incompatible CPUID entry: leaf={:#02x} (subleaf={:#02x}), register='{:?}', \
+                    source VM feature='{:#04x}', destination VM feature'{:#04x}'.",
+                    feature_entry.function, feature_entry.index, feature_entry.feature_reg,
+                    src_vm_feature, dest_vm_feature
+                    );
+
+                compatible = false;
+            }
+        }
+
+        if compatible {
+            info!("No incompatibility detected.");
+            Ok(())
+        } else {
+            Err(Error::CpuidCheckCompatibility)
+        }
     }
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -284,6 +284,13 @@ pub fn start_vmm_thread(
     Ok(thread)
 }
 
+#[derive(Clone, Deserialize, Serialize)]
+struct VmMigrationConfig {
+    vm_config: Arc<Mutex<VmConfig>>,
+    #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+    common_cpuid: hypervisor::CpuId,
+}
+
 pub struct Vmm {
     epoll: EpollContext,
     exit_evt: EventFd,
@@ -743,8 +750,39 @@ impl Vmm {
         socket
             .read_exact(&mut data)
             .map_err(MigratableError::MigrateSocket)?;
-        let config: VmConfig = serde_json::from_slice(&data).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error deserialising config: {}", e))
+
+        let vm_migration_config: VmMigrationConfig =
+            serde_json::from_slice(&data).map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error deserialising config: {}", e))
+            })?;
+
+        // Todo: handle the error better
+        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+        // We check the `CPUID` compatibility of between the source vm and destination, which is
+        // mostly about feature compatibility and "topology/sgx" leaves are not relevant.
+        let dest_cpuid = {
+            let vm_config = &vm_migration_config.vm_config.lock().unwrap();
+            let phys_bits = vm::physical_bits(vm_config.cpus.max_phys_bits);
+            arch::generate_common_cpuid(
+                self.hypervisor.clone(),
+                None,
+                None,
+                phys_bits,
+                vm_config.cpus.kvm_hyperv,
+                #[cfg(feature = "tdx")]
+                vm_config.tdx.is_some(),
+            )
+            .map_err(|_| {
+                MigratableError::MigrateReceive(anyhow!("Error 'generate_common_cpuid'"))
+            })?
+        };
+        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+        arch::CpuidFeatureEntry::check_cpuid_compatibility(
+            &vm_migration_config.common_cpuid,
+            &dest_cpuid,
+        )
+        .map_err(|_| {
+            MigratableError::MigrateReceive(anyhow!("Error 'check_cpuid_compatibility'"))
         })?;
 
         let exit_evt = self.exit_evt.try_clone().map_err(|e| {
@@ -757,7 +795,7 @@ impl Vmm {
             MigratableError::MigrateReceive(anyhow!("Error cloning activate EventFd: {}", e))
         })?;
 
-        self.vm_config = Some(Arc::new(Mutex::new(config)));
+        self.vm_config = Some(vm_migration_config.vm_config);
         let vm = Vm::new_from_migration(
             self.vm_config.clone().unwrap(),
             exit_evt,
@@ -998,7 +1036,31 @@ impl Vmm {
             }
 
             // Send config
-            let config_data = serde_json::to_vec(&vm.get_config()).unwrap();
+            let vm_config = vm.get_config();
+            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+            let common_cpuid = {
+                let phys_bits = vm::physical_bits(vm_config.lock().unwrap().cpus.max_phys_bits);
+                arch::generate_common_cpuid(
+                    self.hypervisor.clone(),
+                    None,
+                    None,
+                    phys_bits,
+                    vm_config.lock().unwrap().cpus.kvm_hyperv,
+                    #[cfg(feature = "tdx")]
+                    vm_config.lock().unwrap().tdx.is_some(),
+                )
+                .map_err(|_| {
+                    MigratableError::MigrateReceive(anyhow!("Error 'generate_common_cpuid'"))
+                })?
+            };
+
+            let vm_migration_config = VmMigrationConfig {
+                vm_config,
+                #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+                common_cpuid,
+            };
+
+            let config_data = serde_json::to_vec(&vm_migration_config).unwrap();
             Request::config(config_data.len() as u64).write_to(&mut socket)?;
             socket
                 .write_all(&config_data)


### PR DESCRIPTION
This refactoring ensures all CPUID related operations are centralized in
`arch::x86_64` module, and exposes only two related public functions to
the vmm crate, e.g. `generate_common_cpuid` and `configure_vcpu`.

Signed-off-by: Bo Chen <chen.bo@intel.com>