### PR TITLE
vmm: Add fallback handling for sending live migration

### DIFF
--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -384,6 +384,59 @@ impl vm::Vm for KvmVm {
     }
 
     ///
+    /// Start logging dirty pages
+    ///
+    fn start_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> vm::Result<()> {
+        let region = self.make_user_memory_region(
+            slot,
+            guest_phys_addr,
+            memory_size,
+            userspace_addr,
+            false,
+            true,
+        );
+        // Safe because guest regions are guaranteed not to overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region(region)
+                .map_err(|e| vm::HypervisorVmError::StartDirtyLog(e.into()))
+        }
+    }
+
+    ///
+    /// Stop logging dirty pages
+    ///
+    fn stop_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> vm::Result<()> {
+        let region = self.make_user_memory_region(
+            slot,
+            guest_phys_addr,
+            memory_size,
+            userspace_addr,
+            false,
+            false,
+        );
+
+        // Safe because guest regions are guaranteed not to overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region(region)
+                .map_err(|e| vm::HypervisorVmError::StopDirtyLog(e.into()))
+        }
+    }
+
+    ///
     /// Get dirty pages bitmap (one bit per page)
     ///
     fn get_dirty_log(&self, slot: u32, memory_size: u64) -> vm::Result<Vec<u64>> {

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -877,6 +877,34 @@ impl vm::Vm for MshvVm {
         Ok(())
     }
     ///
+    /// Start logging dirty pages
+    ///
+    fn start_dirty_log(
+        &self,
+        _slot: u32,
+        _guest_phys_addr: u64,
+        _memory_size: u64,
+        _userspace_addr: u64,
+    ) -> vm::Result<()> {
+        Err(vm::HypervisorVmError::StartDirtyLog(anyhow!(
+            "functionality not implemented"
+        )))
+    }
+    ///
+    /// Stop logging dirty pages
+    ///
+    fn stop_dirty_log(
+        &self,
+        _slot: u32,
+        _guest_phys_addr: u64,
+        _memory_size: u64,
+        _userspace_addr: u64,
+    ) -> vm::Result<()> {
+        Err(vm::HypervisorVmError::StopDirtyLog(anyhow!(
+            "functionality not implemented"
+        )))
+    }
+    ///
     /// Get dirty pages bitmap (one bit per page)
     ///
     fn get_dirty_log(&self, _slot: u32, _memory_size: u64) -> vm::Result<Vec<u64>> {

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -168,6 +168,16 @@ pub enum HypervisorVmError {
     #[error("Failed to write to IO Bus: {0}")]
     IoBusWrite(#[source] anyhow::Error),
     ///
+    /// Start dirty log error
+    ///
+    #[error("Failed to get dirty log: {0}")]
+    StartDirtyLog(#[source] anyhow::Error),
+    ///
+    /// Stop dirty log error
+    ///
+    #[error("Failed to get dirty log: {0}")]
+    StopDirtyLog(#[source] anyhow::Error),
+    ///
     /// Get dirty log error
     ///
     #[error("Failed to get dirty log: {0}")]
@@ -270,6 +280,22 @@ pub trait Vm: Send + Sync {
     fn state(&self) -> Result<VmState>;
     /// Set the VM state
     fn set_state(&self, state: VmState) -> Result<()>;
+    /// Start logging dirty pages
+    fn start_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> Result<()>;
+    /// Stop logging dirty pages
+    fn stop_dirty_log(
+        &self,
+        slot: u32,
+        guest_phys_addr: u64,
+        memory_size: u64,
+        userspace_addr: u64,
+    ) -> Result<()>;
     /// Get dirty pages bitmap
     fn get_dirty_log(&self, slot: u32, memory_size: u64) -> Result<Vec<u64>>;
     #[cfg(feature = "tdx")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2233,9 +2233,7 @@ impl DeviceManager {
                     .memory_manager
                     .lock()
                     .unwrap()
-                    .create_userspace_mapping(
-                        cache_base, cache_size, host_addr, false, false, false,
-                    )
+                    .create_userspace_mapping(cache_base, cache_size, host_addr, false, false)
                     .map_err(DeviceManagerError::MemoryManager)?;
 
                 let region_list = vec![VirtioSharedMemory {
@@ -2426,7 +2424,6 @@ impl DeviceManager {
                 region_size,
                 host_addr,
                 pmem_cfg.mergeable,
-                false,
                 false,
             )
             .map_err(DeviceManagerError::MemoryManager)?;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1049,6 +1049,9 @@ impl Vmm {
             // Send last batch of dirty pages
             Self::vm_maybe_send_dirty_pages(vm, &mut socket)?;
 
+            // Stop logging dirty pages
+            vm.stop_memory_dirty_log()?;
+
             // Capture snapshot and send it
             let vm_snapshot = vm.snapshot()?;
             let snapshot_data = serde_json::to_vec(&vm_snapshot).unwrap();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -980,108 +980,133 @@ impl Vmm {
             send_data_migration.destination_url
         );
         if let Some(ref mut vm) = self.vm {
-            let path = Self::socket_url_to_path(&send_data_migration.destination_url)?;
-            let mut socket = UnixStream::connect(&path).map_err(|e| {
-                MigratableError::MigrateSend(anyhow!("Error connecting to UNIX socket: {}", e))
-            })?;
+            let mut _paused = false;
 
-            // Start the migration
-            Request::start().write_to(&mut socket)?;
-            let res = Response::read_from(&mut socket)?;
-            if res.status() != Status::Ok {
-                warn!("Error starting migration");
-                Request::abandon().write_to(&mut socket)?;
-                Response::read_from(&mut socket).ok();
-                return Err(MigratableError::MigrateSend(anyhow!(
-                    "Error starting migration"
-                )));
-            }
+            match {
+                let path = Self::socket_url_to_path(&send_data_migration.destination_url)?;
+                let mut socket = UnixStream::connect(&path).map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!("Error connecting to UNIX socket: {}", e))
+                })?;
 
-            // Send config
-            let config_data = serde_json::to_vec(&vm.get_config()).unwrap();
-            Request::config(config_data.len() as u64).write_to(&mut socket)?;
-            socket
-                .write_all(&config_data)
-                .map_err(MigratableError::MigrateSocket)?;
-            let res = Response::read_from(&mut socket)?;
-            if res.status() != Status::Ok {
-                warn!("Error during config migration");
-                Request::abandon().write_to(&mut socket)?;
-                Response::read_from(&mut socket).ok();
-                return Err(MigratableError::MigrateSend(anyhow!(
-                    "Error during config migration"
-                )));
-            }
+                // Start the migration
+                Request::start().write_to(&mut socket)?;
+                let res = Response::read_from(&mut socket)?;
+                if res.status() != Status::Ok {
+                    warn!("Error starting migration");
+                    Request::abandon().write_to(&mut socket)?;
+                    Response::read_from(&mut socket).ok();
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Error starting migration"
+                    )));
+                }
 
-            // Start logging dirty pages
-            vm.start_memory_dirty_log()?;
+                // Send config
+                let config_data = serde_json::to_vec(&vm.get_config()).unwrap();
+                Request::config(config_data.len() as u64).write_to(&mut socket)?;
+                socket
+                    .write_all(&config_data)
+                    .map_err(MigratableError::MigrateSocket)?;
+                let res = Response::read_from(&mut socket)?;
+                if res.status() != Status::Ok {
+                    warn!("Error during config migration");
+                    Request::abandon().write_to(&mut socket)?;
+                    Response::read_from(&mut socket).ok();
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Error during config migration"
+                    )));
+                }
 
-            // Send memory table
-            let table = vm.memory_range_table()?;
-            Request::memory(table.length())
-                .write_to(&mut socket)
-                .unwrap();
-            table.write_to(&mut socket)?;
-            // And then the memory itself
-            vm.send_memory_regions(&table, &mut socket)?;
-            let res = Response::read_from(&mut socket)?;
-            if res.status() != Status::Ok {
-                warn!("Error during memory migration");
-                Request::abandon().write_to(&mut socket)?;
-                Response::read_from(&mut socket).ok();
-                return Err(MigratableError::MigrateSend(anyhow!(
-                    "Error during memory migration"
-                )));
-            }
+                // Start logging dirty pages
+                vm.start_memory_dirty_log()?;
 
-            // Try at most 5 passes of dirty memory sending
-            const MAX_DIRTY_MIGRATIONS: usize = 5;
-            for i in 0..MAX_DIRTY_MIGRATIONS {
-                info!("Dirty memory migration {} of {}", i, MAX_DIRTY_MIGRATIONS);
-                if !Self::vm_maybe_send_dirty_pages(vm, &mut socket)? {
-                    break;
+                // Send memory table
+                let table = vm.memory_range_table()?;
+                Request::memory(table.length())
+                    .write_to(&mut socket)
+                    .unwrap();
+                table.write_to(&mut socket)?;
+                // And then the memory itself
+                vm.send_memory_regions(&table, &mut socket)?;
+                let res = Response::read_from(&mut socket)?;
+                if res.status() != Status::Ok {
+                    warn!("Error during memory migration");
+                    Request::abandon().write_to(&mut socket)?;
+                    Response::read_from(&mut socket).ok();
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Error during memory migration"
+                    )));
+                }
+
+                // Try at most 5 passes of dirty memory sending
+                const MAX_DIRTY_MIGRATIONS: usize = 5;
+                for i in 0..MAX_DIRTY_MIGRATIONS {
+                    info!("Dirty memory migration {} of {}", i, MAX_DIRTY_MIGRATIONS);
+                    if !Self::vm_maybe_send_dirty_pages(vm, &mut socket)? {
+                        break;
+                    }
+                }
+
+                // Now pause VM
+                vm.pause()?;
+                _paused = true;
+
+                // Send last batch of dirty pages
+                Self::vm_maybe_send_dirty_pages(vm, &mut socket)?;
+
+                // Capture snapshot and send it
+                let vm_snapshot = vm.snapshot()?;
+                let snapshot_data = serde_json::to_vec(&vm_snapshot).unwrap();
+                Request::state(snapshot_data.len() as u64).write_to(&mut socket)?;
+                socket
+                    .write_all(&snapshot_data)
+                    .map_err(MigratableError::MigrateSocket)?;
+                let res = Response::read_from(&mut socket)?;
+                if res.status() != Status::Ok {
+                    warn!("Error during state migration");
+                    Request::abandon().write_to(&mut socket)?;
+                    Response::read_from(&mut socket).ok();
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Error during state migration"
+                    )));
+                }
+
+                // Complete the migration
+                Request::complete().write_to(&mut socket)?;
+                let res = Response::read_from(&mut socket)?;
+                if res.status() != Status::Ok {
+                    warn!("Error completing migration");
+                    Request::abandon().write_to(&mut socket)?;
+                    Response::read_from(&mut socket).ok();
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "Error completing migration"
+                    )));
+                }
+                info!("Migration complete");
+                Ok(())
+            } {
+                // Stop logging dirty pages and keep the source VM paused unpon successful migration
+                Ok(()) => {
+                    // Stop logging dirty pages
+                    vm.stop_memory_dirty_log()?;
+
+                    Ok(())
+                }
+                // Ensure the source VM continue to run upon unsecessful migration
+                Err(e) => {
+                    // Stop logging dirty pages
+                    vm.stop_memory_dirty_log().map_err(|e| error!("Error stopping logging dirty pages after sending migration failed: {}", e)).unwrap();
+
+                    if _paused {
+                        vm.resume()
+                            .map_err(|e| {
+                                error!("Error resuming VM after sending migraiton failed: {}", e)
+                            })
+                            .unwrap();
+                    }
+
+                    e
                 }
             }
-
-            // Now pause VM
-            vm.pause()?;
-
-            // Send last batch of dirty pages
-            Self::vm_maybe_send_dirty_pages(vm, &mut socket)?;
-
-            // Stop logging dirty pages
-            vm.stop_memory_dirty_log()?;
-
-            // Capture snapshot and send it
-            let vm_snapshot = vm.snapshot()?;
-            let snapshot_data = serde_json::to_vec(&vm_snapshot).unwrap();
-            Request::state(snapshot_data.len() as u64).write_to(&mut socket)?;
-            socket
-                .write_all(&snapshot_data)
-                .map_err(MigratableError::MigrateSocket)?;
-            let res = Response::read_from(&mut socket)?;
-            if res.status() != Status::Ok {
-                warn!("Error during state migration");
-                Request::abandon().write_to(&mut socket)?;
-                Response::read_from(&mut socket).ok();
-                return Err(MigratableError::MigrateSend(anyhow!(
-                    "Error during state migration"
-                )));
-            }
-
-            // Complete the migration
-            Request::complete().write_to(&mut socket)?;
-            let res = Response::read_from(&mut socket)?;
-            if res.status() != Status::Ok {
-                warn!("Error completing migration");
-                Request::abandon().write_to(&mut socket)?;
-                Response::read_from(&mut socket).ok();
-                return Err(MigratableError::MigrateSend(anyhow!(
-                    "Error completing migration"
-                )));
-            }
-            info!("Migration complete");
-            Ok(())
         } else {
             Err(MigratableError::MigrateSend(anyhow!("VM is not running")))
         }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2156,6 +2156,10 @@ impl Vm {
         self.memory_manager.lock().unwrap().start_memory_dirty_log()
     }
 
+    pub fn stop_memory_dirty_log(&self) -> std::result::Result<(), MigratableError> {
+        self.memory_manager.lock().unwrap().stop_memory_dirty_log()
+    }
+
     pub fn dirty_memory_range_table(
         &self,
     ) -> std::result::Result<MemoryRangeTable, MigratableError> {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -765,8 +765,6 @@ impl Vm {
             &config.lock().unwrap().memory.clone(),
             false,
             phys_bits,
-            #[cfg(feature = "tdx")]
-            tdx_enabled,
         )
         .map_err(Error::MemoryManager)?;
 
@@ -887,8 +885,6 @@ impl Vm {
             &config.lock().unwrap().memory.clone(),
             false,
             phys_bits,
-            #[cfg(feature = "tdx")]
-            false,
         )
         .map_err(Error::MemoryManager)?;
 


### PR DESCRIPTION
This patch adds a fallback path for sending live migration, where it
ensures the following behavior of source VM post live-migration:

1. The source VM will be paused only when the migration is completed
successfully, or otherwise it will keep running;

2. The source VM will always stop dirty pages logging;

Fixes: #2895

Signed-off-by: Bo Chen <chen.bo@intel.com>