### PR TITLE
vmm: Fix clippy issue

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -878,11 +878,9 @@ impl MemoryManager {
             }
 
             mm.lock().unwrap().fill_saved_regions(saved_regions)?;
-
-            Ok(mm)
-        } else {
-            Ok(mm)
         }
+
+        Ok(mm)
     }
 
     fn memfd_create(name: &ffi::CStr, flags: u32) -> Result<RawFd, io::Error> {


### PR DESCRIPTION
error: all if blocks contain the same code at the end
   --> vmm/src/memory_manager.rs:884:9
    |
884 | /             Ok(mm)
885 | |         }
    | |_________^
    |

Signed-off-by: Bo Chen <chen.bo@intel.com>